### PR TITLE
Quick "fix" to the Objective Tracker

### DIFF
--- a/Skin/Retail/Interface/AddOns/Blizzard_ObjectiveTracker.lua
+++ b/Skin/Retail/Interface/AddOns/Blizzard_ObjectiveTracker.lua
@@ -298,10 +298,11 @@ do --[[ AddOns\Blizzard_ObjectiveTracker.xml ]]
         bar.BarFrame:Hide()
         bar.IconBG:SetColorTexture(0, 0, 0)
         bar.BarBG:Hide()
-        bar.Icon:SetMask(nil)
+        -- TODO: fix these properly? commenting them out at least stops the errors 
+        -- bar.Icon:SetMask(nil)
         bar.Icon:SetSize(26, 26)
         bar.Icon:SetPoint("RIGHT", 33, 0)
-        Base.CropIcon(bar.Icon)
+        -- Base.CropIcon(bar.Icon)
     end
 
     ----====####$$$$%%%%%%%%%%%%%%%%$$$$####====----


### PR DESCRIPTION
This tends to throw hundreds of errors during Grand Hunts right now.

Reward Icon will not show up properly without a correct fix.